### PR TITLE
Read buffer file name from gltf file

### DIFF
--- a/io_msfs_gltf.py
+++ b/io_msfs_gltf.py
@@ -250,10 +250,12 @@ def create_objects(nodes, meshes):
 
 def load_gltf_file(gltf_file_name):
     gltf_file_path = pathlib.Path(gltf_file_name)
-    bin_file_name = gltf_file_path.with_suffix('.bin')
 
     with open(gltf_file_path, 'r') as handle:
         gltf = json.load(handle)
+
+    assert 'buffers' in gltf and len(gltf['buffers']) == 1, "Unable to handle 0 or multiple buffers"
+    bin_file_name = gltf_file_path.with_name(gltf['buffers']['uri'])
 
     with open(bin_file_name, 'rb') as handle:
         buffer = handle.read()


### PR DESCRIPTION
Only supports a single buffer at this stage. Supporting multiple buffers
would require deeper refactoring of buffer and bufferview code.